### PR TITLE
Show SAST weaknesses only when supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Show SAST Weaknesses only in case the customer is supporting this module, and it's running on Mac.
 - Split authentication into it's own service
+
+### Fixed
+
+- Fixing a bug where clicking on some of the found issues doesn't open the detail sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Suppressing SCA vulnerabilities on Windows was not functioning.
+
+## [1.0.15] - 2024-06-20
+
+### Added
+
+- Show SAST Weaknesses only in case the customer is supporting this module, and it's running on Mac.
+- Split authentication into it's own service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,5 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Fixed
 
-- Fixing a bug where clicking on some of the found issues doesn't open the detail sections
+- Resolving a problem where clicking on some of the found issues doesn't open the detail sections
+- Resolving a problem where scanning a single file through Windows does not initiate a scan.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
         },
         {
           "id": "weaknesses",
-          "name": "Weaknesses"
+          "name": "Weaknesses",
+          "when": "weaknessesViewVisible"
         }
       ]
     },
@@ -108,6 +109,14 @@
       {
         "command": "prisma.open-log",
         "title": "Open Prisma Log"
+      },
+      {
+        "command": "prisma.showWeaknesses",
+        "title": "Show Weaknesses View"
+      },
+      {
+        "command": "prisma.hideWeaknesses",
+        "title": "Hide Weaknesses View"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/bridgecrewio/prisma-cloud-vscode-plugin",
   "icon": "static/icons/prisma.png",
   "description": "a static code analysis tool to scan code for Infrastructure-as-Code (IaC) misconfigurations, Software Composition Analysis (SCA) issues and Secrets vulnerabilities.",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/package.json
+++ b/package.json
@@ -109,14 +109,6 @@
       {
         "command": "prisma.open-log",
         "title": "Open Prisma Log"
-      },
-      {
-        "command": "prisma.showWeaknesses",
-        "title": "Show Weaknesses View"
-      },
-      {
-        "command": "prisma.hideWeaknesses",
-        "title": "Hide Weaknesses View"
       }
     ],
     "menus": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { COMMAND } from '../constants';
 import { CheckovInstall, CheckovExecute, ShowSettings } from './checkov';
-import { CheckovExecutor, ResultsService } from '../services';
+import { CategoriesService, CheckovExecutor, ResultsService } from '../services';
 import { FiltersService } from '../services/filtersService';
 import { LOG_FILE_NAME } from '../logger';
 
@@ -21,6 +21,8 @@ const commands = new Map<COMMAND, (context: vscode.ExtensionContext) => void>([
     [COMMAND.FILTER_HIGH_DISABLE, FiltersService.applyHighSeverityFilter],
     [COMMAND.FILTER_CRITICAL_ENABLE, FiltersService.applyCriticalSeverityFilter],
     [COMMAND.FILTER_CRITICAL_DISABLE, FiltersService.applyCriticalSeverityFilter],
+    [COMMAND.SHOW_WEAKNESSES, CategoriesService.showWeaknessesView],
+    [COMMAND.HIDE_WEAKNESSES, CategoriesService.hideWeaknessesView],
 ]);
 
 export function registerCommands(context: vscode.ExtensionContext): void {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { COMMAND } from '../constants';
 import { CheckovInstall, CheckovExecute, ShowSettings } from './checkov';
-import { CategoriesService, CheckovExecutor, ResultsService } from '../services';
+import { CheckovExecutor, ResultsService } from '../services';
 import { FiltersService } from '../services/filtersService';
 import { LOG_FILE_NAME } from '../logger';
 
@@ -20,7 +20,7 @@ const commands = new Map<COMMAND, (context: vscode.ExtensionContext) => void>([
     [COMMAND.FILTER_HIGH_ENABLE, FiltersService.applyHighSeverityFilter],
     [COMMAND.FILTER_HIGH_DISABLE, FiltersService.applyHighSeverityFilter],
     [COMMAND.FILTER_CRITICAL_ENABLE, FiltersService.applyCriticalSeverityFilter],
-    [COMMAND.FILTER_CRITICAL_DISABLE, FiltersService.applyCriticalSeverityFilter]
+    [COMMAND.FILTER_CRITICAL_DISABLE, FiltersService.applyCriticalSeverityFilter],
 ]);
 
 export function registerCommands(context: vscode.ExtensionContext): void {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,9 +20,7 @@ const commands = new Map<COMMAND, (context: vscode.ExtensionContext) => void>([
     [COMMAND.FILTER_HIGH_ENABLE, FiltersService.applyHighSeverityFilter],
     [COMMAND.FILTER_HIGH_DISABLE, FiltersService.applyHighSeverityFilter],
     [COMMAND.FILTER_CRITICAL_ENABLE, FiltersService.applyCriticalSeverityFilter],
-    [COMMAND.FILTER_CRITICAL_DISABLE, FiltersService.applyCriticalSeverityFilter],
-    [COMMAND.SHOW_WEAKNESSES, CategoriesService.showWeaknessesView],
-    [COMMAND.HIDE_WEAKNESSES, CategoriesService.hideWeaknessesView],
+    [COMMAND.FILTER_CRITICAL_DISABLE, FiltersService.applyCriticalSeverityFilter]
 ]);
 
 export function registerCommands(context: vscode.ExtensionContext): void {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,6 +16,8 @@ export enum COMMAND {
     FILTER_HIGH_DISABLE = 'filter.highDisable',
     FILTER_CRITICAL_ENABLE = 'filter.criticalEnable',
     FILTER_CRITICAL_DISABLE = 'filter.criticalDisable',
+    SHOW_WEAKNESSES = 'prisma.showWeaknesses',
+    HIDE_WEAKNESSES = 'prisma.hideWeaknesses',
     OPEN_PRISMA_LOG = 'prisma.open-log',
 };
 
@@ -129,5 +131,6 @@ export enum IDE_PLUGINS {
 
 export enum GLOBAL_CONTEXT {
     JWT_TOKEN = 'jwtToken',
+    CUSTOMER_MODULES = 'customerModules',
     INSTALLATION_ID = 'installationId',
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,8 +16,6 @@ export enum COMMAND {
     FILTER_HIGH_DISABLE = 'filter.highDisable',
     FILTER_CRITICAL_ENABLE = 'filter.criticalEnable',
     FILTER_CRITICAL_DISABLE = 'filter.criticalDisable',
-    SHOW_WEAKNESSES = 'prisma.showWeaknesses',
-    HIDE_WEAKNESSES = 'prisma.hideWeaknesses',
     OPEN_PRISMA_LOG = 'prisma.open-log',
 };
 

--- a/src/events/onConfigChanged.ts
+++ b/src/events/onConfigChanged.ts
@@ -17,7 +17,7 @@ export class OnConfigChanged {
             }
 
             await AuthenticationService.setAnalyticsJwtToken();
-            await CustomersModulesService.setViewByModules();
+            await CustomersModulesService.fetchAndUpdateViewsByModules();
         }
     }
 };

--- a/src/events/onConfigChanged.ts
+++ b/src/events/onConfigChanged.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { getAccessKey, getSecretKey } from '../config/configUtils';
+import { CustomersModulesService } from '../services/customersModulesService';
+import { AuthenticationService } from '../services/authenticationService';
 
 const message = `You’re about to use the plugin without an API key. This means you’ll be utilizing Checkov open source with limited features. For a more comprehensive analysis and full functionality, we highly recommend using an API key to access the complete capabilities of Prisma Cloud.`;
 
@@ -13,6 +15,9 @@ export class OnConfigChanged {
                 vscode.window.showInformationMessage(message);
                 OnConfigChanged.alreadyPresented = true;
             }
+
+            await AuthenticationService.setAnalyticsJwtToken();
+            await CustomersModulesService.setViewByModules();
         }
     }
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,12 +11,14 @@ import { initializeInstallationId } from './utils';
 import { initiateLogger } from './logger';
 import { initializeAnalyticsService } from './services/analyticsService';
 import { initializeCustomersModulesService } from './services/customersModulesService';
+import { initializeAuthenticationService } from './services/authenticationService';
 
 export async function activate(context: vscode.ExtensionContext) {
 	initiateLogger(context.logUri.fsPath);
 
 	initializeInstallationId(context);
-	await initializeAnalyticsService(context);
+	await initializeAuthenticationService(context);
+	initializeAnalyticsService(context);
 	await initializeCustomersModulesService(context);
 	registerCommands(context);
 	initializeServices(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,19 +3,21 @@ import * as vscode from 'vscode';
 import { registerCommands } from './commands';
 import { COMMAND } from './constants';
 import { registerWindowEvents, registerWorkspaceEvents } from './events';
-import { ResultsService, initializeServices } from './services';
+import { initializeServices } from './services';
 import { registerSidebar } from './views/interface/primarySidebar';
 import { registerCheckovResultView } from './views/interface/checkovResult';
 import { registerCustomHighlight, lineClickDisposable } from './services/customPopupService';
 import { initializeInstallationId } from './utils';
 import { initiateLogger } from './logger';
 import { initializeAnalyticsService } from './services/analyticsService';
+import { initializeCustomersModulesService } from './services/customersModulesService';
 
 export async function activate(context: vscode.ExtensionContext) {
 	initiateLogger(context.logUri.fsPath);
 
 	initializeInstallationId(context);
 	await initializeAnalyticsService(context);
+	await initializeCustomersModulesService(context);
 	registerCommands(context);
 	initializeServices(context);
 	registerWindowEvents();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,8 +18,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	initializeInstallationId(context);
 	await initializeAuthenticationService(context);
-	initializeAnalyticsService(context);
 	await initializeCustomersModulesService(context);
+	initializeAnalyticsService(context);
 	registerCommands(context);
 	initializeServices(context);
 	registerWindowEvents();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,13 +10,14 @@ import { registerCustomHighlight, lineClickDisposable } from './services/customP
 import { initializeInstallationId } from './utils';
 import { initiateLogger } from './logger';
 import { initializeAnalyticsService } from './services/analyticsService';
-import { initializeCustomersModulesService } from './services/customersModulesService';
+import { CustomersModulesService, initializeCustomersModulesService } from './services/customersModulesService';
 import { initializeAuthenticationService } from './services/authenticationService';
 
 export async function activate(context: vscode.ExtensionContext) {
 	initiateLogger(context.logUri.fsPath);
 
 	initializeInstallationId(context);
+	CustomersModulesService.loadCachedData(context);
 	await initializeAuthenticationService(context);
 	await initializeCustomersModulesService(context);
 	initializeAnalyticsService(context);

--- a/src/models/customerModules.ts
+++ b/src/models/customerModules.ts
@@ -1,0 +1,11 @@
+export interface CustomerModulesResponse {
+    modules: CustomerModules
+}
+
+export interface CustomerModules {
+    CICD: boolean,
+    IAC: boolean,
+    SAST: boolean,
+    SCA: boolean,
+    SECRETS: boolean
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './customerModules';

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -9,6 +9,7 @@ export const initializeAnalyticsService = (context: vscode.ExtensionContext) => 
     AnalyticsService.enabled = !!getPrismaApiUrl();
 
     if (AnalyticsService.enabled) {
+        // TODO: don't persisting context object, but get it from general event
         AnalyticsService.applicationContext = context;
     } 
 };

--- a/src/services/authenticationService.ts
+++ b/src/services/authenticationService.ts
@@ -9,6 +9,7 @@ export const initializeAuthenticationService = async (context: vscode.ExtensionC
     AuthenticationService.enabled = !!getPrismaApiUrl();
 
     if (AuthenticationService.enabled) {
+        // TODO: don't persisting context object, but get it from general event
         AuthenticationService.applicationContext = context;
         await AuthenticationService.setAnalyticsJwtToken();
     } 

--- a/src/services/authenticationService.ts
+++ b/src/services/authenticationService.ts
@@ -34,7 +34,7 @@ export class AuthenticationService {
                     await AuthenticationService.applicationContext.globalState.update(GLOBAL_CONTEXT.JWT_TOKEN, response.data.token);
                 }
             } catch (error: any) {
-                logger.info('Is not possible to fetch new JWT token. Authorization on prisma was failed: ', error.message);
+                logger.error('Is not possible to fetch new JWT token. Authorization on prisma was failed: ', error.message);
                 await AuthenticationService.applicationContext.globalState.update(GLOBAL_CONTEXT.JWT_TOKEN, undefined);
             }
         }

--- a/src/services/authenticationService.ts
+++ b/src/services/authenticationService.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import * as vscode from 'vscode';
+import { CONFIG } from "../config";
+import { GLOBAL_CONTEXT } from "../constants";
+import logger from '../logger';
+import { getPrismaApiUrl } from '../config/configUtils';
+
+export const initializeAuthenticationService = async (context: vscode.ExtensionContext) => {
+    AuthenticationService.enabled = !!getPrismaApiUrl();
+
+    if (AuthenticationService.enabled) {
+        AuthenticationService.applicationContext = context;
+        await AuthenticationService.setAnalyticsJwtToken();
+    } 
+};
+
+export class AuthenticationService {
+    static applicationContext: vscode.ExtensionContext;
+    static enabled: boolean = true;
+
+    static async setAnalyticsJwtToken() {
+        const { secretKey, accessKey } = CONFIG.userConfig;
+        if (secretKey && accessKey) {
+            try {
+                const loginUrl = getPrismaApiUrl() + '/login';
+                const response = await axios.post(loginUrl, {
+                    username: accessKey,
+                    password: secretKey,
+                });
+    
+                if (response.status === 200) {
+                    logger.info('Fetched new JWT token successfully');
+                    await AuthenticationService.applicationContext.globalState.update(GLOBAL_CONTEXT.JWT_TOKEN, response.data.token);
+                }
+            } catch (error: any) {
+                logger.info('Is not possible to fetch new JWT token. Authorization on prisma was failed: ', error.message);
+                await AuthenticationService.applicationContext.globalState.update(GLOBAL_CONTEXT.JWT_TOKEN, undefined);
+            }
+        }
+    }
+}

--- a/src/services/categoriesService.ts
+++ b/src/services/categoriesService.ts
@@ -1,4 +1,5 @@
 import { CHECKOV_RESULT_CATEGORY } from "../constants";
+import * as vscode from 'vscode';
 
 export class CategoriesService {
     public static isIaCRisk(checkId: string, checkType: string = ''): boolean {
@@ -38,5 +39,13 @@ export class CategoriesService {
         if (this.isWeaknessesRisk(checkType)) {
             return CHECKOV_RESULT_CATEGORY.WEAKNESSES;
         }
+    }
+
+    public static showWeaknessesView() {
+        vscode.commands.executeCommand('setContext', 'weaknessesViewVisible', true);
+    }
+
+    public static hideWeaknessesView() {
+        vscode.commands.executeCommand('setContext', 'weaknessesViewVisible', false);
     }
 }

--- a/src/services/checkov/executors/pip3.ts
+++ b/src/services/checkov/executors/pip3.ts
@@ -38,6 +38,7 @@ export class Pip3Executor extends AbstractExecutor {
             shell: true,
             env,
             detached: !isWindows(),
+            cwd: '/' // Set to the root directory
         });
 
         Pip3Executor.pid = scanProcess.pid;

--- a/src/services/checkov/executors/pip3.ts
+++ b/src/services/checkov/executors/pip3.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { SpawnOptionsWithoutStdio, spawn } from 'child_process';
 import * as vscode from 'vscode';
 
 import { CONFIG } from '../../../config';
@@ -34,12 +34,18 @@ export class Pip3Executor extends AbstractExecutor {
             env['PRISMA_API_URL'] = prismaApiUrl;
         }
 
-        const scanProcess = spawn(installation.entrypoint, args, {
+        const options: SpawnOptionsWithoutStdio = {
             shell: true,
-            env,
-            detached: !isWindows(),
-            cwd: '/' // Set to the root directory
-        });
+            env: env,
+            detached: !isWindows()
+        };
+        
+        if (isWindows()) {
+            // on windows the cwd is not the root directory, need to adjust it for supporting Checkov
+            options.cwd = '/';
+        }
+        
+        const scanProcess = spawn(installation.entrypoint, args, options);
 
         Pip3Executor.pid = scanProcess.pid;
         const processOutput = await Pip3Executor.handleProcessOutput(scanProcess);

--- a/src/services/checkov/executors/pip3.ts
+++ b/src/services/checkov/executors/pip3.ts
@@ -75,12 +75,18 @@ export class Pip3Executor extends AbstractExecutor {
         if (Array.isArray(result)) {
             for (const output of result) {
                 for (const failedCheck of output.results?.failed_checks) {
-                    failedCheck.repo_file_path = failedCheck.file_abs_path.replace(fsPath, '');
+                    // fixing a cases in windows where the file_abs_path return as "c:/users\\documents"
                     if (isWindows() && isPipInstall()) {
+                        const fsPathLowerFirstLetter = fsPath.charAt(0).toLowerCase() + fsPath.slice(1);
+                        const fsPathUpperFirstLetter = fsPath.charAt(0).toUpperCase() + fsPath.slice(1);
+                        failedCheck.file_abs_path = failedCheck.file_abs_path.replace(/\//g, '\\');
+                        failedCheck.repo_file_path = failedCheck.file_abs_path.replace(fsPathLowerFirstLetter, '').replace(fsPathUpperFirstLetter, '');
                         failedCheck.original_abs_path = failedCheck.file_abs_path;
                         failedCheck.repo_file_path = formatWindowsFilePath(failedCheck.repo_file_path);
                         failedCheck.file_path = formatWindowsFilePath(failedCheck.file_path);
                         failedCheck.file_abs_path = `/${formatWindowsFilePath(failedCheck.file_abs_path)}`;
+                    } else {
+                        failedCheck.repo_file_path = failedCheck.file_abs_path.replace(fsPath, '');
                     }
                 }
             }

--- a/src/services/customersModulesService.ts
+++ b/src/services/customersModulesService.ts
@@ -14,7 +14,7 @@ export const initializeCustomersModulesService = async (context: vscode.Extensio
     if (CustomersModulesService.enabled) {
         CustomersModulesService.applicationContext = context;
 
-        await CustomersModulesService.setViewByModules();
+        await CustomersModulesService.fetchAndUpdateViewsByModules();
     }
 };
 
@@ -71,7 +71,7 @@ export class CustomersModulesService {
 
     }
 
-    static async setViewByModules() {
+    static async fetchModules() {
         // Currently SAST is not supported by Windows
         if (isWindows()) {
             return;
@@ -81,9 +81,10 @@ export class CustomersModulesService {
             await CustomersModulesService.updateCustomerModules();
         } catch (err) {
             logger.info('customer is not supporting SAST');
-            CategoriesService.hideWeaknessesView();
         }
-        
+    }
+
+    static updateViews() {
         const customerModules: CustomerModulesResponse | null | undefined = CustomersModulesService.applicationContext.globalState.get(GLOBAL_CONTEXT.CUSTOMER_MODULES);
         
         if(customerModules && customerModules.modules.SAST) {
@@ -93,5 +94,10 @@ export class CustomersModulesService {
             logger.info('customer is not supporting SAST');
             CategoriesService.hideWeaknessesView();
         }
+    }
+
+    static async fetchAndUpdateViewsByModules() {
+        await CustomersModulesService.fetchModules();
+        CustomersModulesService.updateViews();
     }
 }

--- a/src/services/customersModulesService.ts
+++ b/src/services/customersModulesService.ts
@@ -1,0 +1,81 @@
+import axios, { AxiosResponse } from 'axios';
+import * as vscode from 'vscode';
+import { GLOBAL_CONTEXT, IDE_PLUGINS } from "../constants";
+import logger from '../logger';
+import { getPrismaApiUrl } from '../config/configUtils';
+import { AnalyticsService } from './analyticsService';
+import { CustomerModulesResponse } from '../models';
+import { CategoriesService } from './categoriesService';
+
+export const initializeCustomersModulesService = async (context: vscode.ExtensionContext) => {
+    CustomersModulesService.enabled = !!getPrismaApiUrl();
+
+    if (CustomersModulesService.enabled) {
+        CustomersModulesService.applicationContext = context;
+
+        await CustomersModulesService.getCustomerModules();
+        const customerModules: CustomerModulesResponse | null | undefined = AnalyticsService.applicationContext.globalState.get(GLOBAL_CONTEXT.CUSTOMER_MODULES);
+        
+        if(customerModules && customerModules.modules.SAST) {
+            logger.info('customer is support SAST');
+            CategoriesService.showWeaknessesView();
+        } else {
+            logger.info('customer is not supporting SAST');
+            CategoriesService.hideWeaknessesView();
+        }
+
+    } 
+};
+
+export class CustomersModulesService {
+    private static retryCount: number = 0;
+    static modulesEndpoint: string = getPrismaApiUrl() + '/bridgecrew/api/v1/customer-modules';
+    static applicationContext: vscode.ExtensionContext;
+    static enabled: boolean = true;
+
+
+    static async getCustomerModules() {
+        const token = AnalyticsService.applicationContext.globalState.get(GLOBAL_CONTEXT.JWT_TOKEN) as string;
+
+        if (!CustomersModulesService.enabled || !token) { 
+            logger.error(`CustomersModulesService is not enabled Or token not exists`, {'isEnabled': CustomersModulesService.enabled, token});
+            return; 
+        }
+    
+        const requestBody = [{
+            pluginName: IDE_PLUGINS.VSCODE,
+            eventTime: new Date()
+        }];
+
+        try {
+            const response: AxiosResponse = await axios.get(CustomersModulesService.modulesEndpoint, { headers: {
+                'Authorization': token } });
+
+            logger.info('get customer modules response data: ', { data: response.data });
+            
+            if (response.status === 200) {
+                CustomersModulesService.retryCount = 0;
+                await AnalyticsService.applicationContext.globalState.update(GLOBAL_CONTEXT.CUSTOMER_MODULES, response.data as CustomerModulesResponse);
+            }
+
+            return;
+        } catch (e: any) {
+            if (CustomersModulesService.retryCount === 5) {
+                await AnalyticsService.applicationContext.globalState.update(GLOBAL_CONTEXT.CUSTOMER_MODULES, null);
+                throw new Error('there was an error getting customer modules: ' + e.message);
+            }
+
+            if (e.response.status === 403) {
+                logger.info('Got 403 for analytics, refreshing JWT token');
+                CustomersModulesService.retryCount++;
+                await AnalyticsService.setAnalyticsJwtToken();
+                await CustomersModulesService.getCustomerModules();
+                return;
+            }
+
+            logger.info('Error: ' + e.message);
+            return;
+        }
+
+    }
+}

--- a/src/services/customersModulesService.ts
+++ b/src/services/customersModulesService.ts
@@ -12,6 +12,7 @@ export const initializeCustomersModulesService = async (context: vscode.Extensio
     CustomersModulesService.enabled = !!getPrismaApiUrl();
 
     if (CustomersModulesService.enabled) {
+        // TODO: don't persisting context object, but get it from general event
         CustomersModulesService.applicationContext = context;
 
         await CustomersModulesService.fetchAndUpdateViewsByModules();
@@ -84,8 +85,9 @@ export class CustomersModulesService {
         }
     }
 
-    static updateViews() {
-        const customerModules: CustomerModulesResponse | null | undefined = CustomersModulesService.applicationContext.globalState.get(GLOBAL_CONTEXT.CUSTOMER_MODULES);
+    static updateViews(context?: vscode.ExtensionContext) {
+        const activeContext = context ? context : CustomersModulesService.applicationContext;
+        const customerModules: CustomerModulesResponse | null | undefined = activeContext.globalState.get(GLOBAL_CONTEXT.CUSTOMER_MODULES);
         
         if(customerModules && customerModules.modules.SAST) {
             logger.info('customer is support SAST');
@@ -100,4 +102,8 @@ export class CustomersModulesService {
         await CustomersModulesService.fetchModules();
         CustomersModulesService.updateViews();
     }
+
+    static loadCachedData(context: vscode.ExtensionContext) {
+		this.updateViews(context);
+	}
 }

--- a/src/services/customersModulesService.ts
+++ b/src/services/customersModulesService.ts
@@ -6,6 +6,7 @@ import { getPrismaApiUrl } from '../config/configUtils';
 import { CustomerModulesResponse } from '../models';
 import { CategoriesService } from './categoriesService';
 import { AuthenticationService } from './authenticationService';
+import { isWindows } from '../utils';
 
 export const initializeCustomersModulesService = async (context: vscode.ExtensionContext) => {
     CustomersModulesService.enabled = !!getPrismaApiUrl();
@@ -71,6 +72,11 @@ export class CustomersModulesService {
     }
 
     static async setViewByModules() {
+        // Currently SAST is not supported by Windows
+        if (isWindows()) {
+            return;
+        }
+
         try {
             await CustomersModulesService.updateCustomerModules();
         } catch (err) {

--- a/src/views/interface/checkovResult/webviewPanel.ts
+++ b/src/views/interface/checkovResult/webviewPanel.ts
@@ -10,6 +10,7 @@ import { CategoriesService } from '../../../services';
 import { AnalyticsService } from '../../../services/analyticsService';
 import logger from '../../../logger';
 import { getPrismaApiUrl } from '../../../config/configUtils';
+import { AuthenticationService } from '../../../services/authenticationService';
 
 export class CheckovResultWebviewPanel {
     private static context: vscode.ExtensionContext;
@@ -166,7 +167,7 @@ export class CheckovResultWebviewPanel {
     }
 
     public static async fetchDescription(checkId: string, retryCount = 0): Promise<string | undefined> {
-        const jwtToken = AnalyticsService.applicationContext.globalState.get(GLOBAL_CONTEXT.JWT_TOKEN) as string;
+        const jwtToken = AuthenticationService.applicationContext.globalState.get(GLOBAL_CONTEXT.JWT_TOKEN) as string;
 
         try {
             const response = await axios.get(CheckovResultWebviewPanel.getDescriptionsEndpoint(checkId), { headers: {
@@ -181,7 +182,7 @@ export class CheckovResultWebviewPanel {
             }
 
             if (e.response.status === 403) {
-                await AnalyticsService.setAnalyticsJwtToken();
+                await AuthenticationService.setAnalyticsJwtToken();
                 return await CheckovResultWebviewPanel.fetchDescription(checkId, retryCount + 1);
             }
 


### PR DESCRIPTION
- Show SAST Weaknesses only in case the customer is supporting this module, and it's running on Mac.
- Split authentication into it's own service