### PR TITLE
[BCE-38796] Findings are duplicated using Docker on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
-## [1.0.20] - 2024-09-05
+## [1.0.21] - 2024-09-10
+
+### Fixed
+
+- Fixed an issue where the excluded files warning notification appeared incorrectly
+- Fixed an issue where findings were duplicated when running Checkov using Docker on Windows
+- Fixed an issue where findings didn't appear inline when running Checkov using Docker on Windows
+
+## [1.0.20] - 2024-09-08
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/bridgecrewio/prisma-cloud-vscode-plugin",
   "icon": "static/icons/prisma.png",
   "description": "a static code analysis tool to scan code for Infrastructure-as-Code (IaC) misconfigurations, Software Composition Analysis (SCA) issues and Secrets vulnerabilities.",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/services/checkov/executors/abstractExecutor.ts
+++ b/src/services/checkov/executors/abstractExecutor.ts
@@ -78,7 +78,7 @@ export abstract class AbstractExecutor {
         } else if (vscode.workspace.workspaceFolders) {
             const directory = parseUri(vscode.workspace.workspaceFolders![0].uri);
             checkovCliParams.push('--directory', directory);
-            const excludedPaths = AbstractExecutor.projectPaths.filter(path => !path.startsWith(directory));
+            const excludedPaths = AbstractExecutor.projectPaths.filter(path => !path.replace(/"/g, '').startsWith(directory.replace(/"/g, '')));
             if (excludedPaths.length) {
                 logger.warn(`There are files opened from outside the workspace that won't be scanned in these directories: ${excludedPaths}`);
                 vscode.window.showWarningMessage('You have opened files from outside your workspace. Those files will not be scanned as part of a full scan');

--- a/src/services/resultsService.ts
+++ b/src/services/resultsService.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { CONFIG } from '../config';
 import { CHECKOV_RESULT_CATEGORY } from '../constants';
 import { CheckovResult } from '../types';
-import { isPipInstall, isWindows } from '../utils';
+import { formatWindowsAbsoluteFilePath, isWindows } from '../utils';
 import { TreeDataProvidersContainer } from '../views/interface/primarySidebar/services/treeDataProvidersContainer';
 import { CategoriesService } from './categoriesService';
 import { CustomPopupService } from './customPopupService';
@@ -72,7 +72,7 @@ export class ResultsService {
         const results = ResultsService.get();
         return results.filter(result => {
             if (isWindows()) {
-                return result.file_abs_path === `/${filePath}`;
+                return formatWindowsAbsoluteFilePath(result.file_abs_path) === formatWindowsAbsoluteFilePath(filePath);
             }
             return result.file_abs_path === filePath;
         });
@@ -87,8 +87,8 @@ export class ResultsService {
         const storedResults = ResultsService.get();
         const updatedResults = [
             ...storedResults.filter((result) => {
-                if (isWindows() && isPipInstall()) {
-                    return !files.includes(result.original_abs_path);
+                if (isWindows()) {
+                    return !files.some(file => formatWindowsAbsoluteFilePath(file) === formatWindowsAbsoluteFilePath(result.file_abs_path));
                 }
                 return !files.includes(result.file_abs_path);
             }),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,7 +26,7 @@ export const formatWindowsFilePath = (path: string): string => {
 
 export const formatWindowsAbsoluteFilePath = (path: string): string => {
     const splitPath = path.replace(/\\/g, '/').replace(/^\/+/g, '').split('/');
-    splitPath[0] = splitPath[0].toLocaleUpperCase() + ':';
+    splitPath[0] = splitPath[0].toLocaleUpperCase() + (splitPath[0].endsWith(':') ? '' : ':');
     return splitPath.join('/');
 };
 


### PR DESCRIPTION
## [1.0.21] - 2024-09-10

### Fixed

- Fixed an issue where the excluded files warning notification appeared wrongfully
- Fixed an issue where findings were duplicated when running Checkov using Docker on Windows
- Fixed an issue where findings didn't appear inline when running Checkov using Docker on Windows